### PR TITLE
Fix-up multiple text events from expat

### DIFF
--- a/lib/big-xml.js
+++ b/lib/big-xml.js
@@ -74,10 +74,10 @@ function BigXmlReader(filename, recordRegEx, options) {
     }
     
     if (txt.length > 0) {
-      if (typeof node.text == 'undefined') {
+      if (node.text === undefined) {
         node.text = txt;
       } else {
-        node.text = node.text + txt;
+        node.text += txt;
       }
     }
   });


### PR DESCRIPTION
This code appends text events if it already exists.  This occurs when
processing XML entries such as `&apos;` which come through from expat as
multiple text events.

Example:

``` xml
<bar>Jack&apos;s</bar>
```

comes as 3 text events:
`Jack`,
`\'`, and
`s`

  It also does not assume to modify the XML data.

Before these changes,

``` xml
<foo>J &amp; J</foo>
```

would be processed as:

``` json
{tag: 'foo', text: 'J'}
```

Using appending only, it would be interpted as:

``` json
{tag: 'foo', text: 'J &J'}
```

Eliminating trimLeft() yields 

``` json
{tag: 'foo', text: 'J & J'}
```

which is correct.

The above "Jack's" example also comes through cleanly:

``` xml
<bar>Jack&apos;s</bar>
```

becomes

``` json
{tag: 'foo', text: 'Jack\'s'}
```

as expected.
