### PR TITLE
add the end event into the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ reader.on('record', function(record) {
 });
 ```
 
+You can catch the end event of the record:
+
+```javascript
+reader.on('end', function(){
+  console.log("The XML record is done :)");
+});
+```
+
 The output would take the form:
 
 ```javascript


### PR DESCRIPTION
I've spent some time to find a way to catch the end of the record event, so I add it to the documentation. I know that's nothing but It's also the first time that I contribute on github :D 
Thank you